### PR TITLE
import bugfix for styling and autodeploy

### DIFF
--- a/src/components/AppBar/PrimaryAppBar.js
+++ b/src/components/AppBar/PrimaryAppBar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import styles from './PrimaryAppBar.css';
-import { withStyles } from 'material-ui/styles/index';
-import { AppBar, IconButton, Toolbar, Typography } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import { AppBar, IconButton, Toolbar, Typography } from '@material-ui/core';
 import classNames from 'classnames';
 import MenuIcon from '@material-ui/icons/Menu';
 import Slider from '@material-ui/lab/Slider';

--- a/src/components/Application/Application.js
+++ b/src/components/Application/Application.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from 'material-ui/styles';
-import { Button, Tooltip } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import { Button, Tooltip } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import styles from './Application.css';
 import classNames from 'classnames';

--- a/src/components/Categories/Categories.js
+++ b/src/components/Categories/Categories.js
@@ -5,9 +5,9 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText
-} from 'material-ui';
+} from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
-import { withStyles } from 'material-ui/styles';
+import { withStyles } from '@material-ui/core/styles';
 import styles from './Categories.css';
 import Category from '../Category/Category';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';

--- a/src/components/Category/Category.js
+++ b/src/components/Category/Category.js
@@ -5,13 +5,13 @@ import {
   ListItemSecondaryAction,
   ListItemText,
   Tooltip
-} from 'material-ui';
+} from '@material-ui/core';
 import LabelIcon from '@material-ui/icons/Label';
 import LabelOutlineIcon from '@material-ui/icons/LabelOutline';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { DropTarget } from 'react-dnd';
 import styles from './Category.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 
 const spec = {
   drop(props, monitor, component) {
@@ -60,6 +60,7 @@ class Category extends Component<Properties> {
       visible,
       classes
     } = this.props;
+    console.log(classes);
 
     return connectDropTarget(
       <div

--- a/src/components/ColorPicker/ColorPicker.js
+++ b/src/components/ColorPicker/ColorPicker.js
@@ -1,4 +1,4 @@
-import { withStyles } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
 import React, { Component } from 'react';
 import styles from './ColorPicker.css';
 import { CirclePicker } from 'react-color';

--- a/src/components/CreateCategoryDialog/CreateCategoryDialog.js
+++ b/src/components/CreateCategoryDialog/CreateCategoryDialog.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styles from './CreateCategoryDialog.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import {
   Button,
   Dialog,
@@ -9,7 +9,7 @@ import {
   IconButton,
   TextField,
   Popover
-} from 'material-ui';
+} from '@material-ui/core';
 import LabelIcon from '@material-ui/icons/Label';
 import ColorPicker from '../ColorPicker/ColorPicker';
 

--- a/src/components/DeleteCategoryDialog/DeleteCategoryDialog.js
+++ b/src/components/DeleteCategoryDialog/DeleteCategoryDialog.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styles from './DeleteCategoryDialog.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import {
   Button,
   Dialog,
@@ -8,7 +8,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle
-} from 'material-ui';
+} from '@material-ui/core';
 
 type Properties = {};
 

--- a/src/components/HelpDialog/HelpDialog.js
+++ b/src/components/HelpDialog/HelpDialog.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import styles from './HelpDialog.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText
-} from 'material-ui';
+} from '@material-ui/core';
 
 type Properties = {};
 

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './Main.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 
 const Main = ({ classes }) => {
   return (

--- a/src/components/Primary/Primary.js
+++ b/src/components/Primary/Primary.js
@@ -1,8 +1,8 @@
-import { AppBar, IconButton, Toolbar, Typography } from 'material-ui';
 import React from 'react';
-import styles from './Primary.css';
-import { withStyles } from 'material-ui/styles/index';
+import { AppBar, IconButton, Toolbar, Typography } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
+import styles from './Primary.css';
+import { withStyles } from '@material-ui/core/styles';
 
 const Primary = ({
   classes,

--- a/src/components/SendFeedbackDialog/SendFeedbackDialog.js
+++ b/src/components/SendFeedbackDialog/SendFeedbackDialog.js
@@ -1,7 +1,12 @@
 import React, { Component } from 'react';
 import styles from './SendFeedbackDialog.css';
-import { withStyles } from 'material-ui/styles/index';
-import { Button, Dialog, DialogActions, DialogContent } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent
+} from '@material-ui/core';
 
 type Properties = {};
 

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styles from './Settings.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import {
   AppBar,
   Collapse,
@@ -14,7 +14,7 @@ import {
   Switch,
   Toolbar,
   Typography
-} from 'material-ui';
+} from '@material-ui/core';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';

--- a/src/components/SettingsDialog/SettingsDialog.js
+++ b/src/components/SettingsDialog/SettingsDialog.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import styles from './SettingsDialog.css';
-import { withStyles } from 'material-ui/styles/index';
-import { Dialog } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import { Dialog } from '@material-ui/core';
 import Settings from '../Settings/Settings';
 
 type Properties = {};

--- a/src/components/SettingsDialogTabContainer/SettingsDialogTabContainer.js
+++ b/src/components/SettingsDialogTabContainer/SettingsDialogTabContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './SettingsDialogTabContainer.css';
-import { withStyles } from 'material-ui/styles/index';
-import { Typography } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
 
 const SettingsDialogTabContainer = ({ children }) => {
   return (

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -6,10 +6,10 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText
-} from 'material-ui';
+} from '@material-ui/core';
 import React, { Component } from 'react';
 import styles from './Sidebar.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import ConnectedCategories from '../../containers/ConnectedCategories';
 import HelpDialog from '../HelpDialog/HelpDialog';
 import SettingsIcon from '@material-ui/icons/Settings';

--- a/src/components/SidebarAppBar/SidebarAppBar.js
+++ b/src/components/SidebarAppBar/SidebarAppBar.js
@@ -1,7 +1,13 @@
 import React, { Component } from 'react';
 import styles from './SidebarAppBar.css';
-import { withStyles } from 'material-ui/styles/index';
-import { AppBar, IconButton, Toolbar, Tooltip, Typography } from 'material-ui';
+import { withStyles } from '@material-ui/core/styles';
+import {
+  AppBar,
+  IconButton,
+  Toolbar,
+  Tooltip,
+  Typography
+} from '@material-ui/core';
 import classNames from 'classnames';
 import MenuIcon from '@material-ui/icons/Menu';
 

--- a/src/components/UploadDialog/UploadDialog.js
+++ b/src/components/UploadDialog/UploadDialog.js
@@ -1,16 +1,15 @@
 import React, { Component } from 'react';
 import styles from './UploadDialog.css';
-import { withStyles } from 'material-ui/styles/index';
+import { withStyles } from '@material-ui/core/styles';
 import hash from 'string-hash';
 import * as databaseAPI from '../../database';
-
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle
-} from 'material-ui';
+} from '@material-ui/core';
 
 function createImage(pathname, checksum) {
   return {

--- a/src/stories/Categories.js
+++ b/src/stories/Categories.js
@@ -6,7 +6,7 @@ import { createStore } from 'redux';
 import data from '../images/mnist';
 import reducer from '../reducers';
 import dataImages from '../images/stock';
-import { Divider, Drawer } from 'material-ui';
+import { Divider, Drawer } from '@material-ui/core';
 
 const fixture = {
   categories: data.categories,


### PR DESCRIPTION
The new way of importing material ui elements is using '@material-ui/core' prefix.